### PR TITLE
usePromise / useObservable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A library for integrating [Squid Cloud](https://squid.cloud) with React.
 
 ## Features
 
-* Hooks for easy access to the Squid Client's collections, documents, and queries.
-* A provider for access to the Squid Client anywhere in your React components.
+- Hooks for easy access to the Squid Client's collections, documents, and queries.
+- A provider for access to the Squid Client anywhere in your React components.
 
 ## Getting started
 
@@ -24,14 +24,16 @@ npm install @squidcloud/react
 ### Configure Squid Cloud
 
 Create an **Application** using the [Squid Cloud Console](https://console.squid.cloud).
-* Copy the **Application ID**
-* Add the following provider to your React application:
-```jsx
-import { SquidContextProvider } from "@squidcloud/react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
 
-const root = ReactDOM.createRoot(document.getElementById("root"))
+- Copy the **Application ID**
+- Add the following provider to your React application:
+
+```jsx
+import { SquidContextProvider } from '@squidcloud/react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
 
 root.render(
   <SquidContextProvider
@@ -41,11 +43,13 @@ root.render(
     }}
   >
     <App />
-  </SquidContextProvider>
+  </SquidContextProvider>,
 );
 ```
 
-Note: If you're using a `.env` file for environment management, simply set the `appId` and `region` to your preferred envars.
+Note: If you're using a `.env` file for environment management, simply set the `appId` and `region` to your preferred
+envars.
+
 ```jsx
 <SquidContextProvider
   options={{
@@ -54,98 +58,108 @@ Note: If you're using a `.env` file for environment management, simply set the `
   }}
 >
 ```
-* If you're using an existing application, just reuse the existing application's ID.
+
+- If you're using an existing application, just reuse the existing application's ID.
 
 ### Hooks
+
 Wrapping your application in a `SquidContextProvider` providers the app with access to a `Squid` instance.
 
 To directly reference this instance, your can use the `useSquid` hook.
+
 ```jsx
 function App() {
-  const squid = useSquid()
-  
+  const squid = useSquid();
+
   const foo = () => {
-    squid.executeFunction("foo")
-  }
-  
-  return <button onClick={foo}>Foo</button>
+    squid.executeFunction('foo');
+  };
+
+  return <button onClick={foo}>Foo</button>;
 }
 ```
 
-However, there are some additional hooks to provider easier access to collections (`useCollection`) queries (`useQuery`) and documents (`useDoc`, `useDocs`).
+However, there are some additional hooks to provider easier access to collections (`useCollection`) queries (`useQuery`)
+and documents (`useDoc`, `useDocs`).
 
 #### useCollection
 
-The `useCollection` hook is a simple wrapper around `squid.collection(...)`. It allows you to access a collection without needing a `squid` reference. Once you have a collection, you can use the collection to create queries and manage documents.
-```js
-const collection = useCollection("my-collection")
+The `useCollection` hook is a simple wrapper around `squid.collection(...)`. It allows you to access a collection
+without needing a `squid` reference. Once you have a collection, you can use the collection to create queries and manage
+documents.
 
-const query = collection.query().where("foo", "==", "bar")
-const doc = collection.doc("my-id");
+```js
+const collection = useCollection('my-collection');
+
+const query = collection.query().where('foo', '==', 'bar');
+const doc = collection.doc('my-id');
 ```
 
 #### useQuery
 
 When a query has been created, you use the `useQuery` hook to execute it, and optionally `subscribe` to the results:
+
 ```jsx
 function App() {
-  const collection = useCollection("my-collection");
+  const collection = useCollection('my-collection');
 
   /**
    * The list of docs will be streamed to the client and will be
    * kept up-to-date.
    */
   const docs = useQuery(
-    collection.query().where("foo", ">", "bar"),
-    true /* subscribe */
-  )
+    collection.query().where('foo', '>', 'bar'),
+    true /* subscribe */,
+  );
 
   return (
     <ul>
       {docs.map((d) => (
-        <li key={d.refId}>
-          {d.data.foo}
-        </li>
+        <li key={d.refId}>{d.data.foo}</li>
       ))}
     </ul>
   );
 }
 ```
-If `subscribe` is set to true, data will be streamed to the client and the component will automatically re-render when new updates are received. If `subscribe` is false, the initial data is fetched for the query, but no changes are streamed.
+
+If `subscribe` is set to true, data will be streamed to the client and the component will automatically re-render when
+new updates are received. If `subscribe` is false, the initial data is fetched for the query, but no changes are
+streamed.
 
 #### useDoc
-The `useDoc`hooks provides similar functionality, but instead of subscribing to a query, you subscribe to updates to a particular document. In this case the return value of the hook is not needed since you already have access to the document reference and its data:
+
+The `useDoc`hooks provides similar functionality, but instead of subscribing to a query, you subscribe to updates to a
+particular document. In this case the return value of the hook is not needed since you already have access to the
+document reference and its data:
 
 ```jsx
 function App() {
-  const collection = useCollection("my-collection");
-  const doc = collection.doc("my-id")
+  const collection = useCollection('my-collection');
+  const doc = collection.doc('my-id');
 
   /**
    * Changes to th doc will be streamed to the client and it will be
    * kept up-to-date.
    */
   useDoc(doc, true /* subscribe */);
-  
-  return <span>{doc.data.foo}</span>
+
+  return <span>{doc.data.foo}</span>;
 }
 ```
 
 The same applies for `useDocs`, which can provide updates for multiple document references:
+
 ```jsx
 function App() {
-  const collection = useCollection("my-collection");
-  const docs = [
-    collection.doc("my-id-1"),
-    collection.doc("my-id-2")
-  ]
+  const collection = useCollection('my-collection');
+  const docs = [collection.doc('my-id-1'), collection.doc('my-id-2')];
 
   /**
    * Changes to th documents will be streamed to the client and they will be
    * kept up-to-date.
    */
-  useDocs(docs, true /* subscribe */)
-  
+  useDocs(docs, true /* subscribe */);
+
   return (
     <ul>
       <li>{docs[0].data.foo}</li>
@@ -154,6 +168,81 @@ function App() {
   );
 }
 ```
+
+### Async Hooks
+
+The Squid Client SDK relies heavily on Promises and [Observables](https://rxjs.dev/guide/observable), however some work
+needs to be done to support these kinds of asynchronous updates in React components.
+
+To ensure that all Squid Client SDK
+functionality can be easily integrated into React, Squid exposes the `usePromise` and `useObservable` hooks. These hooks
+allow
+you to use asynchronous functions on the `squid` instance directly in your React components.
+
+#### useObservable
+
+The `useObservable` hook allows you to subscribe to an `Observable<T>` and receive updates within your component. It
+returns an object that includes the following properties:
+
+- `loading`: Whether a value has been received from the observable.
+- `data`: The most recent data received from the observable.
+- `error`: The error object, if the observable encounters an error.
+- `complete`: Whether the observable has completed.
+
+```typescript
+function App() {
+  const [bar, setBar] = useState('bar');
+  const squid = useSquid();
+
+  const { loading, data, error, complete } = useObservable(
+    squid
+      .collection('my-collection')
+      .query()
+      .where('foo', '>', bar)
+      .snapshots(),
+    [], // initialValue
+    [bar], // deps
+  );
+}
+```
+
+Optionally, the hook can also accept an `initialValue` (defaults to `null`) and a `deps` array. When the deps array
+changes, the current observable will unsubscribe, and a new subscription will be created. In the example above, you
+can see the `where` condition of the query relies on the `bar` variable. To ensure that the query is properly updated
+when `bar` changes, we need to pass it as a dependency.
+
+#### usePromise
+
+The `usePromise` hook is similar to `useObservable` but it takes a _**function**_ that returns a `Promise<T>`. The
+reason the hook takes a function instead of a promise directly is to ensure that the promise does not start executing
+until the component mounts.
+
+- `loading`: Whether the promise has resolved or rejected.
+- `data`: The data resolved by the promise.
+- `error`: The error object, if the promise rejected.
+
+```typescript
+function App() {
+  const [bar, setBar] = useState('bar');
+  const squid = useSquid();
+
+  const { loading, data, error } = usePromise(
+    () => {
+      return squid
+        .collection('my-collection')
+        .query()
+        .where('foo', '>', bar)
+        .snapshot();
+    },
+    [], // initialValue
+    [bar], // deps
+  );
+}
+```
+
+The hook can also take an `initialValue` (defaults to `null`) and ` deps` array. Whenever the `deps` change, the result of
+the ongoing promise will be ignored, and a new promise will be created. In the example above, a new promise is created
+each time the `bar` variable changes.
 
 ## API reference
 

--- a/examples/slider/package.json
+++ b/examples/slider/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "clean": "find . \\( -name \"node_modules\" -o -name \"dist\" \\) -type d -exec rm -rf {} +"
   },
   "dependencies": {
     "@squidcloud/react": "file:../..",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/src/index.d.ts",
   "module": "dist/index.esm.js",
   "scripts": {
-    "build": "rollup -c && npm run build:examples",
+    "build": "rollup -c",
     "build:examples": "npm --workspace=examples install && npm --workspace=examples run build",
     "lint": "eslint ./src",
     "format": "prettier --write \"./**/src/**/*.ts\"",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,3 +3,5 @@ export * from './useDoc';
 export * from './useDocs';
 export * from './useQuery';
 export * from './useSquid';
+export * from './usePromise';
+export * from './useObservable';

--- a/src/hooks/useDoc.ts
+++ b/src/hooks/useDoc.ts
@@ -1,28 +1,21 @@
 import { DocumentReference } from '@squidcloud/client';
 import { DocumentData } from '@squidcloud/common';
 import { useEffect, useState } from 'react';
-import { Subscription } from 'rxjs';
+import { from } from 'rxjs';
+import { useObservable } from './useObservable';
 
 export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, subscribe = false): DocumentReference<T> {
   const [_, refresh] = useState<[]>([]);
 
+  const { data } = useObservable<DocumentReference<T> | undefined>(
+    subscribe ? doc.snapshots() : from(doc.snapshot()),
+    undefined,
+    [doc, subscribe],
+  );
+
   useEffect(() => {
-    let subscription: Subscription;
-
-    if (subscribe) {
-      subscription = doc.snapshots().subscribe(() => {
-        refresh([]);
-      });
-    } else {
-      doc.snapshot().then(() => {
-        refresh([]);
-      });
-    }
-
-    return () => {
-      subscription?.unsubscribe();
-    };
-  }, [doc, subscribe]);
+    refresh([]);
+  }, [data]);
 
   return doc;
 }

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -42,12 +42,12 @@ export function useObservable<T>(
           complete: false,
         }),
       error: (error) =>
-        setState({
+        setState((prevState) => ({
+          ...prevState,
           loading: false,
-          data: null,
           error,
           complete: false,
-        }),
+        })),
       complete: () =>
         setState((prevState) => ({
           ...prevState,

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Observable } from 'rxjs';
+
+export type ObservableType<T> = {
+  loading: boolean;
+  data: T;
+  error: any;
+  complete: boolean;
+};
+
+export function useObservable<T>(
+  observable: Observable<T>,
+  initialValue: T,
+  deps?: ReadonlyArray<unknown>,
+): ObservableType<T>;
+export function useObservable<T>(
+  observable: Observable<T>,
+  initialValue?: T,
+  deps?: ReadonlyArray<unknown>,
+): ObservableType<T | null>;
+export function useObservable<T>(
+  observable: Observable<T>,
+  initialValue?: T,
+  deps: ReadonlyArray<unknown> = [],
+): ObservableType<T | null> {
+  const [state, setState] = useState<ObservableType<T | null>>({
+    loading: true,
+    data: initialValue !== undefined ? initialValue : null,
+    error: null,
+    complete: false,
+  });
+
+  const observableMemo = useMemo(() => observable, deps);
+
+  useEffect(() => {
+    const subscription = observableMemo.subscribe({
+      next: (value: T) =>
+        setState({
+          loading: false,
+          data: value,
+          error: null,
+          complete: false,
+        }),
+      error: (error) =>
+        setState({
+          loading: false,
+          data: null,
+          error,
+          complete: false,
+        }),
+      complete: () =>
+        setState((prevState) => ({
+          ...prevState,
+          loading: false,
+          complete: true,
+        })),
+    });
+    return () => subscription.unsubscribe(); // Clean-up function
+  }, [observableMemo]);
+
+  return state;
+}

--- a/src/hooks/usePromise.ts
+++ b/src/hooks/usePromise.ts
@@ -43,11 +43,11 @@ export function usePromise<T>(
       })
       .catch((error) => {
         if (isSubscribed) {
-          setState({
+          setState((prevState) => ({
+            ...prevState,
             loading: false,
-            data: null,
             error,
-          });
+          }));
         }
       });
 

--- a/src/hooks/usePromise.ts
+++ b/src/hooks/usePromise.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export type PromiseType<T = any> = {
+  loading: boolean;
+  data: T | null;
+  error: any;
+};
+
+export function usePromise<T>(
+  promiseFn: () => Promise<T>,
+  initialValue: T,
+  deps?: ReadonlyArray<unknown>,
+): PromiseType<T>;
+export function usePromise<T>(
+  promiseFn: () => Promise<T>,
+  initialValue?: T,
+  deps?: ReadonlyArray<unknown>,
+): PromiseType<T | null>;
+export function usePromise<T>(
+  promiseFn: () => Promise<T>,
+  initialValue?: T,
+  deps: ReadonlyArray<unknown> = [],
+): PromiseType<T | null> {
+  const [state, setState] = useState<PromiseType<T>>({
+    loading: true,
+    data: initialValue !== undefined ? initialValue : null,
+    error: null,
+  });
+
+  const promiseFnMemo = useMemo(() => promiseFn, deps);
+
+  useEffect(() => {
+    let isSubscribed = true;
+    promiseFnMemo()
+      .then((value: T) => {
+        if (isSubscribed) {
+          setState({
+            loading: false,
+            data: value,
+            error: null,
+          });
+        }
+      })
+      .catch((error) => {
+        if (isSubscribed) {
+          setState({
+            loading: false,
+            data: null,
+            error,
+          });
+        }
+      });
+
+    // Prevent setting state if unmounted
+    return () => {
+      isSubscribed = false;
+    };
+  }, [promiseFnMemo]);
+
+  return state;
+}


### PR DESCRIPTION
### Description
Adds `usePromise` and `useObservable` hooks to the Squid React SDK

#### useObservable
The `useObservable` hook takes an `Observable<T>` and returns an object that includes:
- `loading` (whether we've received a value from the observable)
- `data` (the most recent data we've received)
- `error` (whether the observable encountered an error)
- `complete` (whether the observable completed)

Additionally the hook can take an `initialValue` (defaults to null) and ` deps` array. Whenever the `deps` change, the current observable will be unsubscribed, and a new observable will be created. The current observable will also unsubscribe whenever the component unmounts.

#### usePromise
The `usePromise` hook is similar to `useObservable` but it takes a _**function**_ that returns a `Promise<T>`. The reason it takes a function instead of a promise itself is to ensure that the promise does not start executing until the component mounts.

Similar to `useObservable`, the hooks returns the following object:
- `loading` (whether the promise has resolved or rejected)
- `data` (the data the promise resolved with)
- `error` (whether the promise rejected)

The hook can also take an `initialValue` (defaults to null) and ` deps` array. Whenever the `deps` change, the result of the ongoing promise will be ignored, and a new promise will be created. The result of the ongoing promise will also be ignored whenever the component unmounts.

The `useDoc` and `useQuery` hooks have been updated to use `useObservable` under the hood.