### PR TITLE
Pagination with SnapshotEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ The `usePagination` hook is used to paginate through query results. It provides 
 The hook returns an object that includes the following properties:
 
 - `loading`: Whether data is currently being loaded or paginated.
-- `docs`: The paginated results as an array of document references.
-- `data`: The paginated results as an array of data (same as calling docs.map(d => d.data)).
+- `data`: The paginated results as an array. This may be document references, document data, join query results, etc, depending on the type of query that is passed to the hook.
 
 - `hasNext`: A boolean indicating if there are more results available after the current page.
 - `hasPrev`: A boolean indicating if there are more results available before the current page.
@@ -154,8 +153,9 @@ function App() {
    * The list of docs will be streamed to the client and will be kept up-to-date.
    */
   const { docs, loading, hasNext, hasPrev, next, prev } = usePagination(
-    collection.query().sortBy('name'),
+    collection.query().eq('foo', bar).sortBy('name'),
     { subscribe: true, pageSize: 10 } /* PaginationOptions */,
+    [bar], // deps
   );
 
   if (loading) {
@@ -183,6 +183,8 @@ function App() {
 If `subscribe` is set to true, data will be streamed to the client and the component will automatically re-render when new updates are received. If new data is added between the first and last item on your page, your page will automatically update to show the new data, ensuring that only `pageSize` items are visible.
 
 To use pagination, your query must specify a `sortBy`.
+
+Optionally, the hook can also accept a `deps` array. When the deps array changes, a new pagination query will be created.
 
 #### useDoc
 

--- a/examples/slider/src/components/Pages.tsx
+++ b/examples/slider/src/components/Pages.tsx
@@ -1,6 +1,5 @@
-import { usePagination, useCollection, useQuery } from '@squidcloud/react';
+import { useCollection, usePagination, useQuery } from '@squidcloud/react';
 import { Event, Person } from '../App';
-import React from 'react';
 import Slider from './Slider';
 
 const Pages = () => {
@@ -12,13 +11,16 @@ const Pages = () => {
     true,
   );
 
-  const { docs, hasNext, hasPrev, next, prev } = usePagination(
-    people.query().sortBy('age'),
-    {
-      subscribe: true,
-      pageSize: data[0]?.value || 5,
-    },
-  );
+  const {
+    data: docs,
+    hasNext,
+    hasPrev,
+    next,
+    prev,
+  } = usePagination(people.query().sortBy('age'), {
+    subscribe: true,
+    pageSize: data[0]?.value || 5,
+  });
 
   if (loadPageCount || !docs.length) {
     return <span>Loading...</span>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "examples/*"
       ],
       "dependencies": {
-        "@squidcloud/client": "^1.0.87",
-        "@squidcloud/common": "^1.0.69"
+        "@squidcloud/client": "^1.0.88",
+        "@squidcloud/common": "^1.0.70"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -1484,9 +1484,9 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@squidcloud/client": {
-      "version": "1.0.87",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.87.tgz",
-      "integrity": "sha512-VvF3FOUe5fywoyrbd8nqRoYNCJQnykcEqMQOE/C6LVFAJdcbj3BFV1oEsun16vcT0xdIzZ6bACzYRXkgTwRQeA==",
+      "version": "1.0.88",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.88.tgz",
+      "integrity": "sha512-Hmho4wkpp5Ahnp3XOSoUTYECtkA7ypdat3UF5sHqu27i1/y0/qgqUMDFe/MxsepZWacXZHifMHV5tZ2GMbjm+A==",
       "dependencies": {
         "@apollo/client": "^3.7.4",
         "@squidcloud/common": "^1.0.10",
@@ -1500,9 +1500,9 @@
       }
     },
     "node_modules/@squidcloud/common": {
-      "version": "1.0.69",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.69.tgz",
-      "integrity": "sha512-pF7uGi8+jfN/ZQoX4RZbpApVwM8afJ9Ko+JduW6nAxu+Ux++c6y5UHdMh7DjArGppzCF7Lvvb/JGc1CWec/t1w==",
+      "version": "1.0.70",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.70.tgz",
+      "integrity": "sha512-eCtedk0L7dRryk5Sihh/f3g1JVe2+7Snq6dDPE3opdPoTvy+ByNFTR8whoaBnGMp+Ao6RTXZOFTd1MstGD6ZDg==",
       "dependencies": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
@@ -9233,9 +9233,9 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "@squidcloud/client": {
-      "version": "1.0.87",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.87.tgz",
-      "integrity": "sha512-VvF3FOUe5fywoyrbd8nqRoYNCJQnykcEqMQOE/C6LVFAJdcbj3BFV1oEsun16vcT0xdIzZ6bACzYRXkgTwRQeA==",
+      "version": "1.0.88",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.88.tgz",
+      "integrity": "sha512-Hmho4wkpp5Ahnp3XOSoUTYECtkA7ypdat3UF5sHqu27i1/y0/qgqUMDFe/MxsepZWacXZHifMHV5tZ2GMbjm+A==",
       "requires": {
         "@apollo/client": "^3.7.4",
         "@squidcloud/common": "^1.0.10",
@@ -9246,9 +9246,9 @@
       }
     },
     "@squidcloud/common": {
-      "version": "1.0.69",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.69.tgz",
-      "integrity": "sha512-pF7uGi8+jfN/ZQoX4RZbpApVwM8afJ9Ko+JduW6nAxu+Ux++c6y5UHdMh7DjArGppzCF7Lvvb/JGc1CWec/t1w==",
+      "version": "1.0.70",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.70.tgz",
+      "integrity": "sha512-eCtedk0L7dRryk5Sihh/f3g1JVe2+7Snq6dDPE3opdPoTvy+ByNFTR8whoaBnGMp+Ao6RTXZOFTd1MstGD6ZDg==",
       "requires": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
@@ -9265,8 +9265,8 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-terser": "^0.4.0",
-        "@squidcloud/client": "^1.0.87",
-        "@squidcloud/common": "^1.0.69",
+        "@squidcloud/client": "^1.0.88",
+        "@squidcloud/common": "^1.0.70",
         "@types/node": "^18.14.4",
         "@types/react": "^18.0.28",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
@@ -10208,9 +10208,9 @@
           "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
         },
         "@squidcloud/client": {
-          "version": "1.0.87",
-          "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.87.tgz",
-          "integrity": "sha512-VvF3FOUe5fywoyrbd8nqRoYNCJQnykcEqMQOE/C6LVFAJdcbj3BFV1oEsun16vcT0xdIzZ6bACzYRXkgTwRQeA==",
+          "version": "1.0.88",
+          "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.88.tgz",
+          "integrity": "sha512-Hmho4wkpp5Ahnp3XOSoUTYECtkA7ypdat3UF5sHqu27i1/y0/qgqUMDFe/MxsepZWacXZHifMHV5tZ2GMbjm+A==",
           "requires": {
             "@apollo/client": "^3.7.4",
             "@squidcloud/common": "^1.0.10",
@@ -10221,9 +10221,9 @@
           }
         },
         "@squidcloud/common": {
-          "version": "1.0.69",
-          "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.69.tgz",
-          "integrity": "sha512-pF7uGi8+jfN/ZQoX4RZbpApVwM8afJ9Ko+JduW6nAxu+Ux++c6y5UHdMh7DjArGppzCF7Lvvb/JGc1CWec/t1w==",
+          "version": "1.0.70",
+          "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.70.tgz",
+          "integrity": "sha512-eCtedk0L7dRryk5Sihh/f3g1JVe2+7Snq6dDPE3opdPoTvy+ByNFTR8whoaBnGMp+Ao6RTXZOFTd1MstGD6ZDg==",
           "requires": {
             "ajv": "^8.11.2",
             "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rollup-plugin-typescript2": "^0.34.1"
   },
   "dependencies": {
-    "@squidcloud/client": "^1.0.87",
-    "@squidcloud/common": "^1.0.69"
+    "@squidcloud/client": "^1.0.88",
+    "@squidcloud/common": "^1.0.70"
   }
 }

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,10 +1,8 @@
-import { DocumentReference, QueryBuilder } from '@squidcloud/client';
-import { DocumentData, Pagination, PaginationOptions, PaginationState } from '@squidcloud/common';
+import { Pagination, PaginationOptions, PaginationState, SnapshotEmitter } from '@squidcloud/common';
 import { useEffect, useRef, useState } from 'react';
 
-export type PaginationType<T extends DocumentData> = {
+export type PaginationType<T> = {
   loading: boolean;
-  docs: Array<DocumentReference<T>>;
   data: Array<T>;
   hasNext: boolean;
   hasPrev: boolean;
@@ -12,12 +10,13 @@ export type PaginationType<T extends DocumentData> = {
   prev: () => void;
 };
 
-export function usePagination<T extends DocumentData>(
-  query: QueryBuilder<T>,
+export function usePagination<T>(
+  query: SnapshotEmitter<T>,
   options: PaginationOptions,
+  deps: ReadonlyArray<unknown> = [],
 ): PaginationType<T> {
-  const pagination = useRef<Pagination<DocumentReference<T>> | null>(null);
-  const [paginationState, setPaginationState] = useState<PaginationState<DocumentReference<T>>>({
+  const pagination = useRef<Pagination<T> | null>(null);
+  const [paginationState, setPaginationState] = useState<PaginationState<T>>({
     isLoading: true,
     data: [],
     hasNext: false,
@@ -51,14 +50,13 @@ export function usePagination<T extends DocumentData>(
         subscription.unsubscribe();
       }, 0);
     };
-  }, [query.hash, JSON.stringify(options)]);
+  }, [JSON.stringify(deps), JSON.stringify(options)]);
 
   const { isLoading, data, hasNext, hasPrev } = paginationState;
 
   return {
     loading: isLoading,
-    docs: data,
-    data: data.map((d) => d.data),
+    data,
     hasNext,
     hasPrev,
     next: () => !isLoading && pagination.current?.next(),


### PR DESCRIPTION
### Description
Updates the `usePagination` hook to take a `SnapshotEmitter` to support different types of pagination queries.

Since we're no longer taking a standard query, we're now passing through an optional `deps` array to detect when the query has updated.