### PR TITLE
Use Observable, Docs and Query Improvements

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -22,7 +22,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "clean": "rimraf node_modules .yalc",
+    "clean": "rimraf package-lock.json node_modules .yalc",
     "postinstall": "yalc add @squidcloud/react"
   },
   "eslintConfig": {

--- a/examples/create-react-app/src/components/Users.tsx
+++ b/examples/create-react-app/src/components/Users.tsx
@@ -13,7 +13,7 @@ export type PropTypes = {
 const Users = ({ title }: PropTypes) => {
   const collection = useCollection<Person>('people');
 
-  const { data } = useQuery(collection.query(), true);
+  const { data } = useQuery(collection.query().dereference(), true);
 
   const insertFromClient = () => {
     collection.doc().insert({

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -7,7 +7,7 @@
     "build": "npm run clean:cache && next build",
     "start": "next start",
     "lint": "next lint",
-    "clean": "rimraf node_modules dist .next .yalc",
+    "clean": "rimraf package-lock.json node_modules dist .next .yalc",
     "clean:cache": "rimraf .next",
     "postinstall": "yalc add @squidcloud/react"
   },

--- a/examples/next-pages/package.json
+++ b/examples/next-pages/package.json
@@ -7,7 +7,7 @@
     "build": "npm run clean:cache && next build",
     "start": "next start",
     "lint": "next lint",
-    "clean": "rimraf node_modules dist .next .yalc",
+    "clean": "rimraf package-lock.json node_modules dist .next .yalc",
     "clean:cache": "rimraf .next",
     "postinstall": "yalc add @squidcloud/react"
   },

--- a/examples/next-pages/src/components/Users.tsx
+++ b/examples/next-pages/src/components/Users.tsx
@@ -1,5 +1,5 @@
 import { randomAge, randomName } from '@/data/names';
-import { useCollection, useObservable } from '@squidcloud/react';
+import { useCollection, useQuery } from '@squidcloud/react';
 
 export type Person = {
   name: string;
@@ -14,8 +14,9 @@ export type PropTypes = {
 const Users = ({ title, initialData }: PropTypes) => {
   const collection = useCollection<Person>('people');
 
-  const { data } = useObservable(
-    collection.query().dereference().snapshots(),
+  const { data } = useQuery(
+    collection.query().dereference(),
+    true,
     initialData,
   );
 
@@ -27,7 +28,7 @@ const Users = ({ title, initialData }: PropTypes) => {
   };
 
   const insertFromApi = () => {
-    fetch('/api/insertUserFromApi', {
+    fetch('/api/insertUser', {
       method: 'POST',
     }).then();
   };

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "clean": "rimraf node_modules dist .yalc",
+    "clean": "rimraf package-lock.json node_modules dist .yalc",
     "postinstall": "yalc add @squidcloud/react"
   },
   "dependencies": {

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -20,7 +20,10 @@ function App(): JSX.Element {
 
   const people = useCollection<Person>('people');
   const events = useCollection<Event>('events');
-  const { loading, data } = useQuery(events.query().eq('name', 'slider'), true);
+  const { loading, data } = useQuery(
+    events.query().eq('name', 'slider').dereference(),
+    true,
+  );
 
   function toggle(): void {
     setHide(!hide);
@@ -122,16 +125,16 @@ const Docs = <T,>(): JSX.Element => {
 };
 
 const Query = ({ query, description }: QueryProps): JSX.Element => {
-  const { loading, docs } = useQuery(query, true);
+  const { loading, data } = useQuery(query, true);
 
   function update(): void {
-    for (const doc of docs) {
+    for (const doc of data) {
       doc.update({ age: randomAge() }).then();
     }
   }
 
   function remove(): void {
-    for (const doc of docs) {
+    for (const doc of data) {
       doc.delete().then();
     }
   }
@@ -145,7 +148,7 @@ const Query = ({ query, description }: QueryProps): JSX.Element => {
         <span>Loading...</span>
       ) : (
         <ul>
-          {docs.map((d) => {
+          {data.map((d) => {
             return (
               <li key={d.refId}>
                 {d.data.name} {d.data.age}

--- a/examples/vite/src/components/Pages.tsx
+++ b/examples/vite/src/components/Pages.tsx
@@ -7,7 +7,7 @@ const Pages = () => {
   const events = useCollection<Event>('events');
 
   const { loading: loadPageCount, data } = useQuery(
-    events.query().eq('name', 'pageSize'),
+    events.query().eq('name', 'pageSize').dereference(),
     true,
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@squidcloud/react",
       "version": "1.0.17",
       "dependencies": {
-        "@squidcloud/client": "^1.0.89",
-        "@squidcloud/common": "^1.0.71"
+        "@squidcloud/client": "^1.0.98",
+        "@squidcloud/common": "^1.0.80"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -844,9 +844,9 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@squidcloud/client": {
-      "version": "1.0.89",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.89.tgz",
-      "integrity": "sha512-jzeYVvyCobZeffpbgclaNX6cC9oh0t0FlQUfhMSXfB88NVPuvhZPNI829EMCKnp3lI7h4LAP7H0GhBvo11iE8A==",
+      "version": "1.0.98",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.98.tgz",
+      "integrity": "sha512-RETAh55sEgzSlvkMh94RK1ccm/NG28HURpMwhiNZNBoQzjF8gVdJqsJpLC3ThIofFxKUWhGaVOAHzgow9FXJgA==",
       "dependencies": {
         "@apollo/client": "^3.7.4",
         "@squidcloud/common": "^1.0.10",
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/@squidcloud/common": {
-      "version": "1.0.71",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.71.tgz",
-      "integrity": "sha512-2TEHSwMxQTE3Fmv85AwmQlIxI9JjrW/8MtZu3vETt5mrJYgMzyTEnChgrfS7JIk+LQ2m0c/B0U/4b7W+P3mbWw==",
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.80.tgz",
+      "integrity": "sha512-NNoiEqJQnQ5kvLpkfLs52BU32nZgx8w1u3U98mCcuoFk50Ehnnk97U8ntJDLMevqApGHCFOfRnRG+/h7cGLVeQ==",
       "dependencies": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
@@ -9231,9 +9231,9 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "@squidcloud/client": {
-      "version": "1.0.89",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.89.tgz",
-      "integrity": "sha512-jzeYVvyCobZeffpbgclaNX6cC9oh0t0FlQUfhMSXfB88NVPuvhZPNI829EMCKnp3lI7h4LAP7H0GhBvo11iE8A==",
+      "version": "1.0.98",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.98.tgz",
+      "integrity": "sha512-RETAh55sEgzSlvkMh94RK1ccm/NG28HURpMwhiNZNBoQzjF8gVdJqsJpLC3ThIofFxKUWhGaVOAHzgow9FXJgA==",
       "requires": {
         "@apollo/client": "^3.7.4",
         "@squidcloud/common": "^1.0.10",
@@ -9244,9 +9244,9 @@
       }
     },
     "@squidcloud/common": {
-      "version": "1.0.71",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.71.tgz",
-      "integrity": "sha512-2TEHSwMxQTE3Fmv85AwmQlIxI9JjrW/8MtZu3vETt5mrJYgMzyTEnChgrfS7JIk+LQ2m0c/B0U/4b7W+P3mbWw==",
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.80.tgz",
+      "integrity": "sha512-NNoiEqJQnQ5kvLpkfLs52BU32nZgx8w1u3U98mCcuoFk50Ehnnk97U8ntJDLMevqApGHCFOfRnRG+/h7cGLVeQ==",
       "requires": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
-    "@squidcloud/client": "^1.0.89",
-    "@squidcloud/common": "^1.0.71"
+    "@squidcloud/client": "^1.0.98",
+    "@squidcloud/common": "^1.0.80"
   }
 }

--- a/src/hoc/withServerQuery/WithQueryClient.tsx
+++ b/src/hoc/withServerQuery/WithQueryClient.tsx
@@ -3,7 +3,7 @@
 import { deserializeQuery } from '@squidcloud/client';
 import { SerializedQuery } from '@squidcloud/common';
 import React from 'react';
-import { useObservable, useSquid } from '../../hooks';
+import { useQuery, useSquid } from '../../hooks';
 import { WithQueryProps } from './index';
 
 type PropTypes<C extends React.ComponentType<any>, T> = {
@@ -21,10 +21,10 @@ const WithQueryClient = <C extends React.ComponentType<any>, T>({
 }: PropTypes<C, T>) => {
   const squid = useSquid();
 
-  const { data: currentData } = useObservable(
-    deserializeQuery<T>(squid, serializedQuery).snapshots(),
+  const { data: currentData } = useQuery(
+    deserializeQuery<T>(squid, serializedQuery),
+    true,
     data,
-    [],
   );
   const propsWithData = {
     ...props,

--- a/src/hooks/useDoc.ts
+++ b/src/hooks/useDoc.ts
@@ -7,17 +7,16 @@ import { useObservable } from './useObservable';
 
 export type DocType<T extends DocumentData> = {
   loading: boolean;
-  doc: DocumentReference<T>;
   data: T | undefined;
   error: any;
 };
 
 export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, subscribe = false): DocType<T> {
-  const { loading, error, data } = useObservable<DocumentReference<T> | undefined>(
+  const { loading, error, data } = useObservable<T | undefined>(
     () => (subscribe ? doc.snapshots() : from(doc.snapshot())),
-    doc,
+    doc.peek(),
     [doc.refId, subscribe],
   );
 
-  return { loading, error, doc, data: data?.hasData ? data.data : undefined };
+  return { loading, error, data };
 }

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -7,14 +7,13 @@ import { combineLatest } from 'rxjs';
 
 export type DocsType<T extends DocumentData> = {
   loading: boolean;
-  docs: Array<DocumentReference<T>>;
   data: Array<T | undefined>;
   error: any;
 };
 
 export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>>, subscribe = false): DocsType<T> {
   const [loading, setLoading] = useState<boolean>(!!docs.length);
-  const [data, setData] = useState<Array<T | undefined>>(docs.map((d) => (d.hasData ? d.data : undefined)));
+  const [data, setData] = useState<Array<T | undefined>>(docs.map((d) => d.peek()));
   const [error, setError] = useState<any>(null);
 
   useEffect(() => {
@@ -23,8 +22,8 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
     const observables = docs.map((doc) => (subscribe ? doc.snapshots() : doc.snapshot()));
 
     const subscription = combineLatest(observables).subscribe({
-      next: (value: Array<DocumentReference<T> | undefined>) => {
-        setData(value.map((d) => (d?.hasData ? d.data : undefined)));
+      next: (value: Array<T | undefined>) => {
+        setData(value);
         setLoading(false);
       },
       error: (err) => {
@@ -38,5 +37,5 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
     };
   }, [JSON.stringify(docs.map((d) => d.refId)), subscribe]);
 
-  return { loading, error, docs, data };
+  return { loading, error, data };
 }

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -11,17 +11,17 @@ export type ObservableType<T> = {
 };
 
 export function useObservable<T>(
-  observable: Observable<T> | (() => Observable<T>),
+  observable: () => Observable<T>,
   initialValue: T,
   deps?: ReadonlyArray<unknown>,
 ): ObservableType<T>;
 export function useObservable<T>(
-  observable: Observable<T> | (() => Observable<T>),
+  observable: () => Observable<T>,
   initialValue?: T,
   deps?: ReadonlyArray<unknown>,
 ): ObservableType<T | null>;
 export function useObservable<T>(
-  observable: Observable<T> | (() => Observable<T>),
+  observable: () => Observable<T>,
   initialValue?: T,
   deps: ReadonlyArray<unknown> = [],
 ): ObservableType<T | null> {
@@ -32,10 +32,7 @@ export function useObservable<T>(
     complete: false,
   });
 
-  const observableMemo = useMemo(
-    () => (typeof observable === 'function' ? defer(() => observable()) : observable),
-    deps,
-  );
+  const observableMemo = useMemo(() => defer(observable), deps);
 
   useEffect(() => {
     // Set loading state to true when the observable changes


### PR DESCRIPTION
### Description
This PR adds a variety of improvements to our `useObservable`, `useQuery` and `useDoc(s)` hooks:
- `useObservable` now requires the user to pass a function to ensure that a new observable is not created on every render.
- `useQuery` now accepts any kind of query, not just a simple query Because of this:
  - `useQuery` no longer returns `docs` and `data`, it just returns `data`, which matches the expected result type of the query.
  - If users are looking to get `data` instead of document references from a query, they should be adding `.dereference()` to their query.
- `useQuery` now accepts an `initialData` value to be returned before the first result is loaded.
- `useDoc(s)` no longer return `docs` and `data`, it just returns `data`.
- `useQuery` and `useDoc(s)` will now by default try to `peek` at the data if no initial value is passed. If up to date data is available on the client, this will be returned immediately even if `loading` is still `true`.  