### PR TITLE
Pagination no longer has an isLoading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@squidcloud/react",
       "version": "1.0.18",
       "dependencies": {
-        "@squidcloud/client": "^1.0.98",
-        "@squidcloud/common": "^1.0.80"
+        "@squidcloud/client": "^1.0.102",
+        "@squidcloud/common": "^1.0.87"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.0.1",
@@ -844,9 +844,9 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@squidcloud/client": {
-      "version": "1.0.98",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.98.tgz",
-      "integrity": "sha512-RETAh55sEgzSlvkMh94RK1ccm/NG28HURpMwhiNZNBoQzjF8gVdJqsJpLC3ThIofFxKUWhGaVOAHzgow9FXJgA==",
+      "version": "1.0.102",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.102.tgz",
+      "integrity": "sha512-0DkvXywuLOoY9a9ngruNjBJNKCT8C9RKruBPECKuad2FRkuYs4rXzIkk4WmpFH8cuYSdeHHbm+8/Xc3ybnvRrg==",
       "dependencies": {
         "@apollo/client": "^3.7.4",
         "@squidcloud/common": "^1.0.10",
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/@squidcloud/common": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.80.tgz",
-      "integrity": "sha512-NNoiEqJQnQ5kvLpkfLs52BU32nZgx8w1u3U98mCcuoFk50Ehnnk97U8ntJDLMevqApGHCFOfRnRG+/h7cGLVeQ==",
+      "version": "1.0.87",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.87.tgz",
+      "integrity": "sha512-ZsT0a3ebNXQ/H7Vuq7bg6igwEa542aWVuDuRwGF4hOIlemZz4imKh4A0kxnIXPGTweesFUyI9rigRFhor7OoWQ==",
       "dependencies": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
@@ -9231,9 +9231,9 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "@squidcloud/client": {
-      "version": "1.0.98",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.98.tgz",
-      "integrity": "sha512-RETAh55sEgzSlvkMh94RK1ccm/NG28HURpMwhiNZNBoQzjF8gVdJqsJpLC3ThIofFxKUWhGaVOAHzgow9FXJgA==",
+      "version": "1.0.102",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.102.tgz",
+      "integrity": "sha512-0DkvXywuLOoY9a9ngruNjBJNKCT8C9RKruBPECKuad2FRkuYs4rXzIkk4WmpFH8cuYSdeHHbm+8/Xc3ybnvRrg==",
       "requires": {
         "@apollo/client": "^3.7.4",
         "@squidcloud/common": "^1.0.10",
@@ -9244,9 +9244,9 @@
       }
     },
     "@squidcloud/common": {
-      "version": "1.0.80",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.80.tgz",
-      "integrity": "sha512-NNoiEqJQnQ5kvLpkfLs52BU32nZgx8w1u3U98mCcuoFk50Ehnnk97U8ntJDLMevqApGHCFOfRnRG+/h7cGLVeQ==",
+      "version": "1.0.87",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.87.tgz",
+      "integrity": "sha512-ZsT0a3ebNXQ/H7Vuq7bg6igwEa542aWVuDuRwGF4hOIlemZz4imKh4A0kxnIXPGTweesFUyI9rigRFhor7OoWQ==",
       "requires": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
-    "@squidcloud/client": "^1.0.98",
-    "@squidcloud/common": "^1.0.80"
+    "@squidcloud/client": "^1.0.102",
+    "@squidcloud/common": "^1.0.87"
   }
 }

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -30,13 +30,17 @@ export function usePagination<T>(
       prev: () => { return; },
     });
 
-  useEffect(() => {
+  function setLoading() {
     setPaginationState((prevState) => ({
       ...prevState,
       loading: true,
       hasNext: false,
       hasPrev: false,
     }));
+  }
+
+  useEffect(() => {
+    setLoading();
 
     pagination.current = query.paginate(options);
     const subscription = pagination.current.observeState().subscribe((state) => {
@@ -45,8 +49,14 @@ export function usePagination<T>(
         data: state.data,
         hasNext: state.hasNext,
         hasPrev: state.hasPrev,
-        next: () => pagination.current?.next(),
-        prev: () => pagination.current?.prev(),
+        next: () => {
+          setLoading();
+          pagination.current?.next()
+        },
+        prev: () => {
+          setLoading();
+          pagination.current?.prev()
+        },
       });
     });
 


### PR DESCRIPTION
The newest client doesn't have an isLoading field in the pagination state, and only pushes new state when there's new state to push. This PR upgrades to that client and makes the relevant changes in the React stuff.
