### PR TITLE
Fix: AI & useObservable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@squidcloud/react",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@squidcloud/react",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "dependencies": {
         "@squidcloud/client": "^1.0.121",
         "@squidcloud/common": "^1.0.106"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidcloud/react",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Squid React SDK",
   "types": "dist/cjs/index.d.ts",
   "main": "dist/cjs/index.js",

--- a/src/hooks/useAiAssistant.ts
+++ b/src/hooks/useAiAssistant.ts
@@ -29,7 +29,7 @@ export function useAiAssistant(integrationId: IntegrationId, profileId: string) 
   useEffect(() => {
     const recentChat = history[history.length - 1];
 
-    if (!recentChat || !data) return;
+    if (!recentChat || !data || loading) return;
 
     if (recentChat.type === 'user') {
       setHistory((prevMessages) => prevMessages.concat({ id: generateId(), type: 'ai', message: data }));
@@ -40,7 +40,7 @@ export function useAiAssistant(integrationId: IntegrationId, profileId: string) 
         return newMessages;
       });
     }
-  }, [data, complete]);
+  }, [data, complete, loading]);
 
   const chat = (prompt: string) => {
     setHistory((messages) => messages.concat({ id: generateId(), type: 'user', message: prompt }));

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -45,9 +45,11 @@ export function useObservable<T>(
   useEffect(() => {
     // Set loading state to true when the observable changes
     if (!state.loading) {
+      // We don't reset the data here to ensure that the user still has access to the data
+      // from the previously emitted value while the new value is loading. This is important
+      // to prevent UI flashes of data, etc.
       setState((prevState) => ({
         ...prevState,
-        data: initialValue !== undefined ? initialValue : null,
         loading: true,
         complete: false,
       }));


### PR DESCRIPTION
### Description
Provides a different solution to the fix addressed in https://github.com/squidcloudio/squid-react/pull/29. Instead of the clearing the cached data in the observable, we now no longer append to the messages list if the observable is loading.