### PR TITLE
Query Deps

### DIFF
--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -19,12 +19,14 @@ type GetReturnType<T> = T extends SnapshotEmitter<infer U> ? U : never;
  * @param query The query object.
  * @param subscribe If true, subscribe to query snapshots. Default is false.
  * @param initialValue The initial value of the data.
+ * @param deps Array of dependencies for the hook. Default is [].
  * @returns The query data, loading state, and error.
  */
 export function useQuery<T extends DocumentData>(
   query: T & SnapshotEmitter<any>,
   subscribe = false,
   initialValue?: Array<GetReturnType<T>>,
+  deps: ReadonlyArray<unknown> = [],
 ): QueryType<GetReturnType<T>> {
   const peekInitialValue = () => {
     try {
@@ -36,7 +38,7 @@ export function useQuery<T extends DocumentData>(
   const { loading, error, data } = useObservable<GetReturnType<T>[]>(
     () => (subscribe ? query.snapshots() : from(query.snapshot())),
     initialValue || peekInitialValue(),
-    [JSON.stringify(query.serialize()), subscribe],
+    [JSON.stringify(query.serialize()), subscribe, JSON.stringify(deps)],
   );
   return { loading, error, data };
 }


### PR DESCRIPTION
### Description
Adds optional `deps` to the `useQuery` hook that can be used to re-execute the query.