### PR TITLE
Options and Enabled

### DIFF
--- a/examples/create-react-app/src/components/Users.tsx
+++ b/examples/create-react-app/src/components/Users.tsx
@@ -13,7 +13,9 @@ export type PropTypes = {
 const Users = ({ title }: PropTypes) => {
   const collection = useCollection<Person>('people');
 
-  const { data } = useQuery(collection.query().dereference(), true);
+  const { data } = useQuery(collection.query().dereference(), {
+    subscribe: true,
+  });
 
   const insertFromClient = () => {
     collection.doc().insert({

--- a/examples/next-app/src/app/page.tsx
+++ b/examples/next-app/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
   const UsersWithQuery = withServerQuery(
     Users,
     squid.collection<Person>('people').query().dereference(),
-    true,
+    { subscribe: true },
   );
   return <UsersWithQuery title="Users" />;
 }

--- a/examples/next-pages/src/components/Users.tsx
+++ b/examples/next-pages/src/components/Users.tsx
@@ -16,7 +16,7 @@ const Users = ({ title, initialData }: PropTypes) => {
 
   const { data } = useQuery(
     collection.query().dereference(),
-    true,
+    { subscribe: true },
     initialData,
   );
 

--- a/examples/next-pages/src/components/Users.tsx
+++ b/examples/next-pages/src/components/Users.tsx
@@ -14,11 +14,10 @@ export type PropTypes = {
 const Users = ({ title, initialData }: PropTypes) => {
   const collection = useCollection<Person>('people');
 
-  const { data } = useQuery(
-    collection.query().dereference(),
-    { subscribe: true },
+  const { data } = useQuery(collection.query().dereference(), {
+    subscribe: true,
     initialData,
-  );
+  });
 
   const insertFromClient = () => {
     collection.doc().insert({

--- a/examples/vite/src/components/Chat.tsx
+++ b/examples/vite/src/components/Chat.tsx
@@ -1,9 +1,9 @@
-import { useAiAssistant } from '@squidcloud/react';
+import { useAiChatbot } from '@squidcloud/react';
 import { useState } from 'react';
 
 const Chat = () => {
   const [value, setValue] = useState('');
-  const { history, chat, complete } = useAiAssistant('rudder', 'grandma');
+  const { history, chat, complete } = useAiChatbot('rudder', 'grandma');
 
   const handleClick = () => {
     chat(value);

--- a/examples/vite/src/components/Pages.tsx
+++ b/examples/vite/src/components/Pages.tsx
@@ -2,13 +2,13 @@ import { useCollection, usePagination, useQuery } from '@squidcloud/react';
 import { Event, Person } from '../App';
 import Slider from './Slider';
 
-const Pages = () => {
+const Pages = ({ enabled }: { enabled: boolean }) => {
   const people = useCollection<Person>('people');
   const events = useCollection<Event>('events');
 
   const { loading: loadPageCount, data } = useQuery(
     events.query().eq('name', 'pageSize').dereference(),
-    true,
+    { subscribe: true },
   );
 
   const {
@@ -20,6 +20,7 @@ const Pages = () => {
   } = usePagination(people.query().sortBy('age'), {
     subscribe: true,
     pageSize: data[0]?.value || 5,
+    enabled,
   });
 
   if (loadPageCount || !docs.length) {

--- a/examples/vite/src/components/Slider.tsx
+++ b/examples/vite/src/components/Slider.tsx
@@ -14,7 +14,7 @@ const Slider = ({ name, min, max, defaultValue }: PropTypes) => {
   const events = useCollection<Event>('events');
 
   const doc = events.doc(name);
-  const { data } = useDoc(doc, true);
+  const { data } = useDoc(doc, { subscribe: true });
 
   useEffect(() => {
     const createSlider = async (): Promise<void> => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-config-next": "13.4.12",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-unused-imports": "^2.0.0",
+        "magic-string": "^0.30.5",
         "npm-check-updates": "^16.10.8",
         "prettier": "^2.8.4",
         "prettier-plugin-organize-imports": "^3.2.3",
@@ -621,6 +622,18 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -4685,12 +4698,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -6467,18 +6480,6 @@
       },
       "peerDependencies": {
         "rollup": "2.x || 3.x"
-      }
-    },
-    "node_modules/rollup-plugin-preserve-directives/node_modules/magic-string": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/rollup-plugin-typescript2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@squidcloud/react",
       "version": "1.0.41",
       "dependencies": {
-        "@squidcloud/client": "^1.0.144",
-        "@squidcloud/common": "^1.0.144",
+        "@squidcloud/client": "^1.0.150",
+        "@squidcloud/common": "^1.0.150",
         "assertic": "^1.0.0"
       },
       "devDependencies": {
@@ -792,16 +792,17 @@
       }
     },
     "node_modules/@squidcloud/client": {
-      "version": "1.0.144",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.144.tgz",
-      "integrity": "sha512-nbXV3ZgEnxjnM5e3YJQ/UNv+Jf5SkmHf7mR046cjHQER5kxaa9o+ZnOu7wAOSg6BBEoI+0Bq2Val0N6EFwxOrw==",
+      "version": "1.0.150",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.150.tgz",
+      "integrity": "sha512-pmYmgMjCWB9QA45LXYsZ0JQyCIEaa0gKi7CkjGOhHojsTLSgZMOga8bZO2qlFVwNkEPaWYMwc8jv83Vw7aXoRQ==",
       "dependencies": {
         "@apollo/client": "^3.7.4",
-        "@squidcloud/common": "1.0.144",
+        "@squidcloud/common": "1.0.150",
         "@supercharge/promise-pool": "^2.3.2",
         "axios": "^1.6.2",
         "cross-fetch": "^3.1.5",
         "lodash": "^4.17.21",
+        "otrie": "1.1.2",
         "ws": "^8.13.0"
       },
       "peerDependencies": {
@@ -809,9 +810,9 @@
       }
     },
     "node_modules/@squidcloud/common": {
-      "version": "1.0.144",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.144.tgz",
-      "integrity": "sha512-v5wRhsBsCkDsy2hRT2o2e9m6itJMHxhGgWL2Jei8i/z/CaFPkgxnKKisgSFn1HCB5dvSrGA4g5jYaQU3uPpGBg==",
+      "version": "1.0.150",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.150.tgz",
+      "integrity": "sha512-cekUcUY9C7s4JwPUlgWQXektNB8/vphJXNQyeewM/D8/MG5M34usfF+KuyMdN3IlXMQTTthznidnQRq9PJEv6Q==",
       "dependencies": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
@@ -5627,6 +5628,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/otrie": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/otrie/-/otrie-1.1.2.tgz",
+      "integrity": "sha512-97dE1x8h6NsBx8AcVWO1GEXlONSQ/h4hpq7KPa5UmMGm/NZUr8OnlC/umBx64dJmRjmcj25lBTMv189+oxEnvg==",
+      "dependencies": {
+        "assertic": "^1.0.0",
+        "ptrie": "^1.0.1",
+        "rxjs": "^7.5.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -6021,6 +6035,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/ptrie": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ptrie/-/ptrie-1.0.1.tgz",
+      "integrity": "sha512-OT9FqyP3+s87VDpyxAR8A2JVFGNby4QDgRduA5memUEVDccK/VRfMz0T0q6d2xjCzhFOlioOlFGSKoMhGQMKWA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -6645,7 +6667,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-config-next": "13.4.12",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-unused-imports": "^2.0.0",
+        "magic-string": "^0.30.5",
         "npm-check-updates": "^16.10.8",
         "prettier": "^2.8.4",
         "prettier-plugin-organize-imports": "^3.2.3",
@@ -621,6 +622,18 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -4753,12 +4766,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -6580,18 +6593,6 @@
       },
       "peerDependencies": {
         "rollup": "2.x || 3.x"
-      }
-    },
-    "node_modules/rollup-plugin-preserve-directives/node_modules/magic-string": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/rollup-plugin-typescript2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@squidcloud/react",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@squidcloud/react",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "dependencies": {
-        "@squidcloud/client": "^1.0.152",
-        "@squidcloud/common": "^1.0.152",
+        "@squidcloud/client": "^1.0.156",
+        "@squidcloud/common": "^1.0.156",
         "assertic": "^1.0.0"
       },
       "devDependencies": {
@@ -792,12 +792,12 @@
       }
     },
     "node_modules/@squidcloud/client": {
-      "version": "1.0.152",
-      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.152.tgz",
-      "integrity": "sha512-kWwl/fZ9ZDik1+/UuEZIiuq6rg3FTKjDT1cK6mS+QQ85yxTM4zFPChieL2XdsKMUJr/IPxObofow9A30qfj7Qg==",
+      "version": "1.0.156",
+      "resolved": "https://registry.npmjs.org/@squidcloud/client/-/client-1.0.156.tgz",
+      "integrity": "sha512-8QqZnahBqfCYYN9pl4mu9h9p3gKJrnF8BK3uw9M9hllWGC0EzmYMrRdugAJSxdHsO87FRA7OxxymTTbq8l/Now==",
       "dependencies": {
         "@apollo/client": "^3.7.4",
-        "@squidcloud/common": "1.0.152",
+        "@squidcloud/common": "^1.0.156",
         "@supercharge/promise-pool": "^2.3.2",
         "axios": "^1.6.2",
         "cross-fetch": "^3.1.5",
@@ -810,9 +810,9 @@
       }
     },
     "node_modules/@squidcloud/common": {
-      "version": "1.0.152",
-      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.152.tgz",
-      "integrity": "sha512-BSpfMbLf7WhPUb6/vOrbGjcCOuqkw+xA8Aeoifm30adTsh0xXB8WyqGIF50mhAeu0YKHvmji2id586qnNWZi5A==",
+      "version": "1.0.156",
+      "resolved": "https://registry.npmjs.org/@squidcloud/common/-/common-1.0.156.tgz",
+      "integrity": "sha512-9rOI8d1mzXGWar7G7VltbF3dt2V+gHUd/KMTwpZhjT6BhKkMSb86OvMoFnuZm79nmgLwdRnIN57SXNjgCY67qA==",
       "dependencies": {
         "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
@@ -7930,9 +7930,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.0.tgz",
-      "integrity": "sha512-H/Z3H55mrcrgjFwI+5jKavgXvwQLtfPCUEp6pi35VhoB0pfcHnSoyuTzkBEZpzq49g1193CUEwIvmsjcotenYw==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
+      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.39",
   "description": "Squid React SDK",
   "types": "dist/cjs/index.d.ts",
-  "main": "dist/cjs/src/index.js",
+  "main": "dist/cjs/index.js",
   "scripts": {
     "build": "rollup -c && yalc push",
     "lint": "eslint ./src",
@@ -38,6 +38,7 @@
     "eslint-config-next": "13.4.12",
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "magic-string": "^0.30.5",
     "npm-check-updates": "^16.10.8",
     "prettier": "^2.8.4",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidcloud/react",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Squid React SDK",
   "types": "dist/cjs/index.d.ts",
   "main": "dist/cjs/index.js",
@@ -55,8 +55,8 @@
     "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
-    "@squidcloud/client": "^1.0.152",
-    "@squidcloud/common": "^1.0.152",
+    "@squidcloud/client": "^1.0.156",
+    "@squidcloud/common": "^1.0.156",
     "assertic": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "yalc": "^1.0.0-pre.53"
   },
   "dependencies": {
-    "@squidcloud/client": "^1.0.144",
-    "@squidcloud/common": "^1.0.144",
+    "@squidcloud/client": "^1.0.150",
+    "@squidcloud/common": "^1.0.150",
     "assertic": "^1.0.0"
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,9 @@
+import glob from 'glob';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import MagicString from 'magic-string';
+
 import del from 'rollup-plugin-delete';
 import polyfills from 'rollup-plugin-node-polyfills';
 import external from 'rollup-plugin-peer-deps-external';
@@ -7,9 +13,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
-import preserveDirectives from 'rollup-plugin-preserve-directives';
 
-const input = 'src/index.ts';
 const plugins = [
   del({ targets: 'dist/*', runOnce: true }),
   typescript(),
@@ -21,18 +25,26 @@ const plugins = [
   terser({
     compress: { directives: false },
   }),
-  preserveDirectives({
-    supressPreserveModulesWarning: true,
-  }),
+  preserveDirectives(),
 ];
 
 export default [
   {
     external: ['@squidcloud/client', '@squidcloud/common'],
-    input,
+    input: Object.fromEntries(
+      glob
+        .sync('src/**/*.{tsx,ts}')
+        .map((file) => [
+          path.relative(
+            'src',
+            file.slice(0, file.length - path.extname(file).length),
+          ),
+
+          fileURLToPath(new URL(file, import.meta.url)),
+        ]),
+    ),
     output: [
       {
-        preserveModules: true,
         dir: 'dist/cjs',
         format: 'cjs',
         sourcemap: true,
@@ -53,3 +65,69 @@ export default [
     },
   },
 ];
+
+function preserveDirectives() {
+  return {
+    name: 'preserve-directives',
+    // Capture directives metadata during the transform phase
+    transform(code) {
+      const ast = this.parse(code);
+
+      if (ast.type === 'Program' && ast.body) {
+        const directives = [];
+        let i = 0;
+
+        // Nodes in body should never be falsy, but issue #5 tells us otherwise
+        // so just in case we filter them out here
+        const filteredBody = ast.body.filter(Boolean);
+
+        // .type must be defined according to the spec, but just in case..
+        while (filteredBody[i]?.type === 'ExpressionStatement') {
+          const node = filteredBody[i];
+          if (node.directive) {
+            directives.push(node.directive);
+          }
+          i += 1;
+        }
+
+        if (directives.length > 0) {
+          return {
+            code,
+            ast,
+            map: null,
+            meta: { preserveDirectives: directives },
+          };
+        }
+      }
+      return { code, ast, map: null };
+    },
+    renderChunk: {
+      order: 'post',
+      handler(code, chunk) {
+        let chunkHasDirectives = false;
+
+        if ('modules' in chunk) {
+          for (const moduleId of Object.keys(chunk.modules)) {
+            const directives =
+              this.getModuleInfo(moduleId)?.meta?.preserveDirectives;
+            if (directives) {
+              chunkHasDirectives = directives;
+            }
+          }
+
+          if (chunkHasDirectives) {
+            const directiveStrings = chunkHasDirectives
+              .map((directive) => `'${directive}'`)
+              .join(';\n');
+
+            const s = new MagicString(code);
+            s.prepend(`${directiveStrings};\n`);
+            const srcMap = s.generateMap({ includeContent: true });
+            return { code: s.toString(), map: srcMap };
+          }
+        }
+        return null;
+      },
+    },
+  };
+}

--- a/src/hoc/withServerQuery/WithQueryClient.tsx
+++ b/src/hoc/withServerQuery/WithQueryClient.tsx
@@ -34,7 +34,7 @@ const WithQueryClient = <C extends React.ComponentType<any>, T>({
 
   const { data: currentData } = useQuery(
     deserializeQuery<T>(squid, serializedQuery),
-    true,
+    { subscribe: true },
     data,
   );
   const propsWithData = {

--- a/src/hoc/withServerQuery/WithQueryClient.tsx
+++ b/src/hoc/withServerQuery/WithQueryClient.tsx
@@ -34,8 +34,7 @@ const WithQueryClient = <C extends React.ComponentType<any>, T>({
 
   const { data: currentData } = useQuery(
     deserializeQuery<T>(squid, serializedQuery),
-    { subscribe: true },
-    data,
+    { subscribe: true, initialData: data },
   );
   const propsWithData = {
     ...props,

--- a/src/hoc/withServerQuery/WithQueryServer.tsx
+++ b/src/hoc/withServerQuery/WithQueryServer.tsx
@@ -1,13 +1,17 @@
 import { SnapshotEmitter } from '@squidcloud/common';
 import React from 'react';
 import WithQueryClient from './WithQueryClient';
-import { WithQueryProps } from './index';
+import {
+  DefaultWithQueryOptions,
+  WithQueryOptions,
+  WithQueryProps,
+} from './index';
 
 type PropTypes<C extends React.ComponentType<any>, T> = {
   Component: C;
   props: Omit<React.ComponentProps<C>, keyof WithQueryProps<T>>;
   query: SnapshotEmitter<T>;
-  subscribe: boolean;
+  options?: WithQueryOptions;
 };
 
 /**
@@ -18,23 +22,25 @@ type PropTypes<C extends React.ComponentType<any>, T> = {
  * @param Component - The component to wrap.
  * @param props - The props of the Component.
  * @param query - The query object.
- * @param subscribe - If true, the Component will subscribe to the query snapshots.
+ * @param options - Options to control the behavior of the HOC.
  * @returns The Component wrapped with the query data, or a WithQueryClient component if subscribe is true.
  */
 const WithQueryServer = async <C extends React.ComponentType<any>, T>({
   Component,
   props,
   query,
-  subscribe,
+  options,
 }: PropTypes<C, T>) => {
   const data = await query.snapshot();
+
+  const mergedOptions = { ...DefaultWithQueryOptions, ...options };
 
   const propsWithData = {
     ...props,
     data,
   } as React.ComponentProps<C>;
 
-  if (!subscribe) {
+  if (!mergedOptions.subscribe) {
     return <Component {...propsWithData} />;
   }
 

--- a/src/hoc/withServerQuery/WithQueryServer.tsx
+++ b/src/hoc/withServerQuery/WithQueryServer.tsx
@@ -2,7 +2,7 @@ import { SnapshotEmitter } from '@squidcloud/common';
 import React from 'react';
 import WithQueryClient from './WithQueryClient';
 import {
-  DefaultWithQueryOptions,
+  DEFAULT_WITH_QUERY_OPTIONS,
   WithQueryOptions,
   WithQueryProps,
 } from './index';
@@ -33,7 +33,7 @@ const WithQueryServer = async <C extends React.ComponentType<any>, T>({
 }: PropTypes<C, T>) => {
   const data = await query.snapshot();
 
-  const mergedOptions = { ...DefaultWithQueryOptions, ...options };
+  const mergedOptions = { ...DEFAULT_WITH_QUERY_OPTIONS, ...options };
 
   const propsWithData = {
     ...props,

--- a/src/hoc/withServerQuery/index.tsx
+++ b/src/hoc/withServerQuery/index.tsx
@@ -6,6 +6,17 @@ export interface WithQueryProps<T> {
   data: Array<T>;
 }
 
+export type WithQueryOptions = {
+  /**
+   * If true, the Component will subscribe to the query snapshots. Defaults to `true`.
+   */
+  subscribe?: boolean;
+};
+
+export const DefaultWithQueryOptions: Required<WithQueryOptions> = {
+  subscribe: true,
+};
+
 /**
  * Higher Order Component (HOC) to wrap a component with a server query.
  *
@@ -13,13 +24,13 @@ export interface WithQueryProps<T> {
  * @template T - The type of the data in the query.
  * @param Component - The component to wrap.
  * @param query - The query object.
- * @param subscribe - Whether to subscribe to query snapshots. Default is false.
+ * @param options - Options to control the behavior of the HOC.
  * @returns A new component that wraps the given component with the server query.
  */
 export const withServerQuery = <C extends React.ComponentType<any>, T>(
   Component: C,
   query: SnapshotEmitter<T>,
-  subscribe = false,
+  options?: WithQueryOptions,
 ) => {
   const withQuery: React.FC<
     Omit<React.ComponentProps<C>, keyof WithQueryProps<T>>
@@ -30,7 +41,7 @@ export const withServerQuery = <C extends React.ComponentType<any>, T>(
         props={props}
         Component={Component}
         query={query}
-        subscribe={subscribe}
+        options={options}
       />
     );
   };

--- a/src/hoc/withServerQuery/index.tsx
+++ b/src/hoc/withServerQuery/index.tsx
@@ -13,7 +13,7 @@ export type WithQueryOptions = {
   subscribe?: boolean;
 };
 
-export const DefaultWithQueryOptions: Required<WithQueryOptions> = {
+export const DEFAULT_WITH_QUERY_OPTIONS: Required<WithQueryOptions> = {
   subscribe: true,
 };
 

--- a/src/hooks/useAiAssistant.ts
+++ b/src/hooks/useAiAssistant.ts
@@ -77,6 +77,7 @@ function useAiHook(integrationId: string, aiQuery: boolean, profileId?: string):
         return squid.ai().assistant(integrationId).profile(profileId).chat(question, aiAssistantOptions);
       }
     },
+    {},
     '',
     [question],
   );

--- a/src/hooks/useAiChatbot.ts
+++ b/src/hooks/useAiChatbot.ts
@@ -77,8 +77,7 @@ function useAiHook(integrationId: string, aiQuery: boolean, profileId?: string):
         return squid.ai().chatbot(integrationId).profile(profileId).chat(question, aiChatbotOptions);
       }
     },
-    {},
-    '',
+    { initialData: '' },
     [question],
   );
 

--- a/src/hooks/useDoc.ts
+++ b/src/hooks/useDoc.ts
@@ -19,17 +19,30 @@ export type DocType<T extends DocumentData> = {
   error: any;
 };
 
+export type DocOptions = {
+  /**
+   * Determines whether to query the document data automatically. Defaults to `true`. When set to `false`, executing the
+   * query will be delayed until `enabled` is set to `true`.
+   */
+  enabled?: boolean;
+  /** Whether to subscribe to document updates. Default is false. */
+  subscribe?: boolean;
+};
+
 /**
  * Hook to get a Squid document data, loading state, and errors.
  *
  * @template T extends DocumentData
  * @param doc Squid document reference.
- * @param subscribe Whether to subscribe to document updates. Default is false.
+ * @param options Options to control the behavior of the document query.
  * @returns The document data, loading state, and errors.
  */
-export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, subscribe = false): DocType<T> {
+export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, options?: DocOptions): DocType<T> {
+  const { enabled, subscribe } = options || {};
+
   const { loading, error, data } = useObservable<T | undefined>(
     () => (subscribe ? doc.snapshots() : from(doc.snapshot())),
+    { enabled },
     doc.peek(),
     [doc.refId, subscribe],
   );

--- a/src/hooks/useDoc.ts
+++ b/src/hooks/useDoc.ts
@@ -2,7 +2,6 @@
 
 import { DocumentReference } from '@squidcloud/client';
 import { DocumentData } from '@squidcloud/common';
-import { useMemo } from 'react';
 import { from } from 'rxjs';
 import { useObservable } from './useObservable';
 
@@ -44,10 +43,8 @@ export const DefaultDocOptions: Required<DocOptions> = {
  * @param options Options to control the behavior of the document query.
  * @returns The document data, loading state, and errors.
  */
-export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, options?: DocOptions): DocType<T> {
-  const mergedOptions = useMemo(() => {
-    return { ...DefaultDocOptions, ...options };
-  }, [JSON.stringify(options)]);
+export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, options: DocOptions = {}): DocType<T> {
+  const mergedOptions = { ...DefaultDocOptions, ...options };
 
   const { enabled, subscribe } = mergedOptions;
 

--- a/src/hooks/useDoc.ts
+++ b/src/hooks/useDoc.ts
@@ -30,7 +30,7 @@ export type DocOptions = {
   subscribe?: boolean;
 };
 
-export const DefaultDocOptions: Required<DocOptions> = {
+export const DEFAULT_DOC_OPTIONS: Required<DocOptions> = {
   enabled: true,
   subscribe: true,
 };
@@ -44,7 +44,7 @@ export const DefaultDocOptions: Required<DocOptions> = {
  * @returns The document data, loading state, and errors.
  */
 export function useDoc<T extends DocumentData>(doc: DocumentReference<T>, options: DocOptions = {}): DocType<T> {
-  const mergedOptions = { ...DefaultDocOptions, ...options };
+  const mergedOptions = { ...DEFAULT_DOC_OPTIONS, ...options };
 
   const { enabled, subscribe } = mergedOptions;
 

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -2,9 +2,9 @@
 
 import { DocumentReference } from '@squidcloud/client';
 import { DocumentData } from '@squidcloud/common';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { combineLatest } from 'rxjs';
-import { DocOptions } from './useDoc';
+import { DefaultDocOptions, DocOptions } from './useDoc';
 
 /**
  * Represents the state and collection of document data returned from a query within the Squid framework.
@@ -33,10 +33,14 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
   const [data, setData] = useState<Array<T | undefined>>(docs.map((d) => d.peek()));
   const [error, setError] = useState<any>(null);
 
+  const mergedOptions = useMemo(() => {
+    return { ...DefaultDocOptions, ...options };
+  }, [JSON.stringify(options)]);
+
   useEffect(() => {
     setLoading(!!docs.length);
 
-    const { enabled = true, subscribe } = options || {};
+    const { enabled, subscribe } = mergedOptions;
     if (!enabled) return;
 
     const observables = docs.map((doc) => (subscribe ? doc.snapshots() : doc.snapshot()));
@@ -55,7 +59,7 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
     return () => {
       setTimeout(() => subscription.unsubscribe(), 0);
     };
-  }, [JSON.stringify(docs.map((d) => d.refId)), JSON.stringify(options)]);
+  }, [JSON.stringify(docs.map((d) => d.refId)), JSON.stringify(mergedOptions)]);
 
   return { loading, error, data };
 }

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -2,7 +2,7 @@
 
 import { DocumentReference } from '@squidcloud/client';
 import { DocumentData } from '@squidcloud/common';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { combineLatest } from 'rxjs';
 import { DefaultDocOptions, DocOptions } from './useDoc';
 
@@ -33,9 +33,7 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
   const [data, setData] = useState<Array<T | undefined>>(docs.map((d) => d.peek()));
   const [error, setError] = useState<any>(null);
 
-  const mergedOptions = useMemo(() => {
-    return { ...DefaultDocOptions, ...options };
-  }, [JSON.stringify(options)]);
+  const mergedOptions = { ...DefaultDocOptions, ...options };
 
   useEffect(() => {
     setLoading(!!docs.length);

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -4,6 +4,7 @@ import { DocumentReference } from '@squidcloud/client';
 import { DocumentData } from '@squidcloud/common';
 import { useEffect, useState } from 'react';
 import { combineLatest } from 'rxjs';
+import { DocOptions } from './useDoc';
 
 /**
  * Represents the state and collection of document data returned from a query within the Squid framework.
@@ -24,16 +25,19 @@ export type DocsType<T extends DocumentData> = {
  *
  * @template T extends DocumentData
  * @param docs Array of Squid document references.
- * @param subscribe Whether to subscribe to documents updates. Default is false.
+ * @param options Options to control the behavior of the of the document queries.
  * @returns The documents data, loading state, and errors.
  */
-export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>>, subscribe = false): DocsType<T> {
+export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>>, options?: DocOptions): DocsType<T> {
   const [loading, setLoading] = useState<boolean>(!!docs.length);
   const [data, setData] = useState<Array<T | undefined>>(docs.map((d) => d.peek()));
   const [error, setError] = useState<any>(null);
 
   useEffect(() => {
     setLoading(!!docs.length);
+
+    const { enabled = true, subscribe } = options || {};
+    if (!enabled) return;
 
     const observables = docs.map((doc) => (subscribe ? doc.snapshots() : doc.snapshot()));
 
@@ -51,7 +55,7 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
     return () => {
       setTimeout(() => subscription.unsubscribe(), 0);
     };
-  }, [JSON.stringify(docs.map((d) => d.refId)), subscribe]);
+  }, [JSON.stringify(docs.map((d) => d.refId)), JSON.stringify(options)]);
 
   return { loading, error, data };
 }

--- a/src/hooks/useDocs.ts
+++ b/src/hooks/useDocs.ts
@@ -4,7 +4,7 @@ import { DocumentReference } from '@squidcloud/client';
 import { DocumentData } from '@squidcloud/common';
 import { useEffect, useState } from 'react';
 import { combineLatest } from 'rxjs';
-import { DefaultDocOptions, DocOptions } from './useDoc';
+import { DEFAULT_DOC_OPTIONS, DocOptions } from './useDoc';
 
 /**
  * Represents the state and collection of document data returned from a query within the Squid framework.
@@ -33,7 +33,7 @@ export function useDocs<T extends DocumentData>(docs: Array<DocumentReference<T>
   const [data, setData] = useState<Array<T | undefined>>(docs.map((d) => d.peek()));
   const [error, setError] = useState<any>(null);
 
-  const mergedOptions = { ...DefaultDocOptions, ...options };
+  const mergedOptions = { ...DEFAULT_DOC_OPTIONS, ...options };
 
   useEffect(() => {
     setLoading(!!docs.length);

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -30,7 +30,7 @@ export type ObservableOptions<T> = {
   initialData?: T;
 };
 
-const DefaultObservableOption: Required<ObservableOptions<null>> = {
+const DEFAULT_OBSERVABLE_OPTIONS: Required<ObservableOptions<null>> = {
   enabled: true,
   initialData: null,
 };
@@ -60,7 +60,7 @@ export function useObservable<T>(
   options: ObservableOptions<T> = {},
   deps: ReadonlyArray<unknown> = [],
 ): ObservableType<T | null> {
-  const mergedOptions = { ...DefaultObservableOption, ...options };
+  const mergedOptions = { ...DEFAULT_OBSERVABLE_OPTIONS, ...options };
 
   const [state, setState] = useState<ObservableType<T | null>>({
     loading: true,

--- a/src/hooks/useObservable.ts
+++ b/src/hooks/useObservable.ts
@@ -41,23 +41,26 @@ const DefaultObservableOption: Required<ObservableOptions<null>> = {
  *
  * @template T - The type of data the observable emits.
  * @param observable - A function that returns the observable to subscribe to.
- * @param options Options to control the behavior of the observable.
+ * @param options - Options to control the behavior of the observable.
  * @param deps - Optional array of dependencies that, when changed, will re-subscribe to the provided observable function.
  * @returns An object containing the observable's current loading state, the latest data emitted, any errors encountered, and completion state.
  */
 export function useObservable<T>(
   observable: () => Observable<T>,
-  options: ObservableOptions<T>,
+  options: ObservableOptions<T> & { initialData: T },
   deps?: ReadonlyArray<unknown>,
 ): ObservableType<T>;
 export function useObservable<T>(
   observable: () => Observable<T>,
   options?: ObservableOptions<T>,
+  deps?: ReadonlyArray<unknown>,
+): ObservableType<T | null>;
+export function useObservable<T>(
+  observable: () => Observable<T>,
+  options: ObservableOptions<T> = {},
   deps: ReadonlyArray<unknown> = [],
 ): ObservableType<T | null> {
-  const mergedOptions = useMemo(() => {
-    return { ...DefaultObservableOption, ...options };
-  }, [JSON.stringify(options)]);
+  const mergedOptions = { ...DefaultObservableOption, ...options };
 
   const [state, setState] = useState<ObservableType<T | null>>({
     loading: true,
@@ -66,7 +69,7 @@ export function useObservable<T>(
     complete: false,
   });
 
-  const observableMemo = useMemo(observable, [JSON.stringify(deps), JSON.stringify(mergedOptions)]);
+  const observableMemo = useMemo(observable, [JSON.stringify(deps), mergedOptions.enabled]);
 
   useEffect(() => {
     // Set loading state to true when the observable changes

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -33,6 +33,10 @@ export interface PaginationOptions extends SquidPaginationOptions {
   enabled?: boolean;
 }
 
+const DefaultPaginationOptions: Required<Omit<PaginationOptions, keyof SquidPaginationOptions>> = {
+  enabled: true,
+};
+
 /**
  * Hook that provides a simple interface for paginating data from a Squid query.
  * It returns the current pagination state including the data for the current page,
@@ -50,6 +54,8 @@ export function usePagination<T>(
   options: PaginationOptions,
   deps: ReadonlyArray<unknown> = [],
 ): PaginationType<GetReturnType<T>> {
+  const mergedOptions = { ...DefaultPaginationOptions, ...options };
+
   const pagination = useRef<Pagination<GetReturnType<T>> | null>(null);
   const [paginationState, setPaginationState] = useState<PaginationType<GetReturnType<T>>>({
     loading: true,
@@ -76,10 +82,10 @@ export function usePagination<T>(
   useEffect(() => {
     setLoading();
 
-    const { enabled = true } = options;
+    const { enabled } = mergedOptions;
     if (!enabled) return;
 
-    pagination.current = query.paginate(options);
+    pagination.current = query.paginate(mergedOptions);
     const subscription = pagination.current.observeState().subscribe((state) => {
       setPaginationState({
         loading: false,
@@ -104,7 +110,7 @@ export function usePagination<T>(
         subscription.unsubscribe();
       }, 0);
     };
-  }, [JSON.stringify(deps), JSON.stringify(options)]);
+  }, [JSON.stringify(deps), JSON.stringify(mergedOptions)]);
 
   return paginationState;
 }

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { Pagination, PaginationOptions, SnapshotEmitter } from '@squidcloud/common';
+import { Pagination, SnapshotEmitter, PaginationOptions as SquidPaginationOptions } from '@squidcloud/common';
 import { useEffect, useRef, useState } from 'react';
 
 /**
@@ -24,6 +24,14 @@ export type PaginationType<T> = {
 };
 
 type GetReturnType<T> = T extends SnapshotEmitter<infer U> ? U : never;
+
+export interface PaginationOptions extends SquidPaginationOptions {
+  /**
+   * Determines whether to execute the pagination query automatically. Defaults to `true`. When set to `false`,
+   * executing the query will be delayed until `enabled` is set to `true`.
+   */
+  enabled?: boolean;
+}
 
 /**
  * Hook that provides a simple interface for paginating data from a Squid query.
@@ -67,6 +75,9 @@ export function usePagination<T>(
 
   useEffect(() => {
     setLoading();
+
+    const { enabled = true } = options;
+    if (!enabled) return;
 
     pagination.current = query.paginate(options);
     const subscription = pagination.current.observeState().subscribe((state) => {

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -33,7 +33,7 @@ export interface PaginationOptions extends SquidPaginationOptions {
   enabled?: boolean;
 }
 
-const DefaultPaginationOptions: Required<Omit<PaginationOptions, keyof SquidPaginationOptions>> = {
+const DEFAULT_PAGINATION_OPTIONS: Required<Omit<PaginationOptions, keyof SquidPaginationOptions>> = {
   enabled: true,
 };
 
@@ -54,7 +54,7 @@ export function usePagination<T>(
   options: PaginationOptions,
   deps: ReadonlyArray<unknown> = [],
 ): PaginationType<GetReturnType<T>> {
-  const mergedOptions = { ...DefaultPaginationOptions, ...options };
+  const mergedOptions = { ...DEFAULT_PAGINATION_OPTIONS, ...options };
 
   const pagination = useRef<Pagination<GetReturnType<T>> | null>(null);
   const [paginationState, setPaginationState] = useState<PaginationType<GetReturnType<T>>>({

--- a/src/hooks/usePromise.ts
+++ b/src/hooks/usePromise.ts
@@ -12,7 +12,7 @@ export type PromiseType<T = any> = {
   /** Indicates whether the promise is currently being resolved. */
   loading: boolean;
   /** The data resolved by the promise, if any. */
-  data: T | null;
+  data: T;
   /** Any error that may have been thrown during the promise resolution. */
   error: any;
 };
@@ -45,25 +45,28 @@ const DefaultPromiseOptions: Required<ObservableOptions<null>> = {
  */
 export function usePromise<T>(
   promiseFn: () => Promise<T>,
-  options: PromiseOptions<T>,
+  options: PromiseOptions<T> & { initialData: T },
   deps?: ReadonlyArray<unknown>,
 ): PromiseType<T>;
 export function usePromise<T>(
   promiseFn: () => Promise<T>,
   options?: PromiseOptions<T>,
+  deps?: ReadonlyArray<unknown>,
+): PromiseType<T | null>;
+export function usePromise<T>(
+  promiseFn: () => Promise<T>,
+  options: PromiseOptions<T> = {},
   deps: ReadonlyArray<unknown> = [],
 ): PromiseType<T | null> {
-  const mergedOptions = useMemo(() => {
-    return { ...DefaultPromiseOptions, ...options };
-  }, [JSON.stringify(options)]);
+  const mergedOptions = { ...DefaultPromiseOptions, ...options };
 
-  const [state, setState] = useState<PromiseType<T>>({
+  const [state, setState] = useState<PromiseType<T | null>>({
     loading: true,
     data: mergedOptions.initialData,
     error: null,
   });
 
-  const promiseFnMemo = useMemo(() => promiseFn, [JSON.stringify(deps), JSON.stringify(options)]);
+  const promiseFnMemo = useMemo(() => promiseFn, [JSON.stringify(deps), mergedOptions.enabled]);
 
   useEffect(() => {
     // Set loading state to true when the observable changes

--- a/src/hooks/usePromise.ts
+++ b/src/hooks/usePromise.ts
@@ -27,7 +27,7 @@ export type PromiseOptions<T> = {
   initialData?: T;
 };
 
-const DefaultPromiseOptions: Required<ObservableOptions<null>> = {
+const DEFAULT_PROMISE_OPTIONS: Required<ObservableOptions<null>> = {
   enabled: true,
   initialData: null,
 };
@@ -58,7 +58,7 @@ export function usePromise<T>(
   options: PromiseOptions<T> = {},
   deps: ReadonlyArray<unknown> = [],
 ): PromiseType<T | null> {
-  const mergedOptions = { ...DefaultPromiseOptions, ...options };
+  const mergedOptions = { ...DEFAULT_PROMISE_OPTIONS, ...options };
 
   const [state, setState] = useState<PromiseType<T | null>>({
     loading: true,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { DocumentData, SnapshotEmitter } from '@squidcloud/common';
-import { useMemo } from 'react';
 import { from } from 'rxjs';
 import { useObservable } from './useObservable';
 
@@ -38,7 +37,7 @@ export type QueryOptions<T> = {
    * An optional array of initial data items to be used before the query resolves for the first time. If a parent query
    * is active, this defaults to data currently available the client. Otherwise, the default is an empty array.
    */
-  initialData: Array<GetReturnType<T>>;
+  initialData?: Array<GetReturnType<T>>;
 };
 
 const DefaultQueryOptions: Required<QueryOptions<null>> = {
@@ -60,12 +59,10 @@ const DefaultQueryOptions: Required<QueryOptions<null>> = {
  */
 export function useQuery<T extends DocumentData>(
   query: T & SnapshotEmitter<any>,
-  options?: QueryOptions<T>,
+  options: QueryOptions<T> = {},
   deps: ReadonlyArray<unknown> = [],
 ): QueryType<GetReturnType<T>> {
-  const mergedOptions = useMemo(() => {
-    return { ...DefaultQueryOptions, ...options };
-  }, [JSON.stringify(options)]);
+  const mergedOptions = { ...DefaultQueryOptions, ...options };
 
   const peekInitialValue = () => {
     try {
@@ -75,11 +72,11 @@ export function useQuery<T extends DocumentData>(
     }
   };
 
-  const { enabled, subscribe } = mergedOptions;
+  const { enabled, subscribe, initialData } = mergedOptions;
 
   const { loading, error, data } = useObservable<GetReturnType<T>[]>(
     () => (subscribe ? query.snapshots() : from(query.snapshot())),
-    { enabled, initialData: options?.initialData || peekInitialValue() },
+    { enabled, initialData: initialData || peekInitialValue() },
     [JSON.stringify(query.serialize()), subscribe, JSON.stringify(deps)],
   );
   return { loading, error, data };

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -40,7 +40,7 @@ export type QueryOptions<T> = {
   initialData?: Array<GetReturnType<T>>;
 };
 
-const DefaultQueryOptions: Required<QueryOptions<null>> = {
+const DEFAULT_QUERY_OPTIONS: Required<QueryOptions<null>> = {
   enabled: true,
   subscribe: true,
   initialData: [],
@@ -62,7 +62,7 @@ export function useQuery<T extends DocumentData>(
   options: QueryOptions<T> = {},
   deps: ReadonlyArray<unknown> = [],
 ): QueryType<GetReturnType<T>> {
-  const mergedOptions = { ...DefaultQueryOptions, ...options };
+  const mergedOptions = { ...DEFAULT_QUERY_OPTIONS, ...options };
 
   const peekInitialValue = () => {
     try {

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -20,6 +20,16 @@ export type QueryType<T> = {
 
 type GetReturnType<T> = T extends SnapshotEmitter<infer U> ? U : never;
 
+export type QueryOptions = {
+  /**
+   * Determines whether the query runs automatically. Defaults to `true`. When set to `false`, executing the query will
+   * be delayed until `enabled` is set to `true`.
+   */
+  enabled?: boolean;
+  /** Determines whether to continuously subscribe to query updates. If `false`, a single snapshot will be fetched. */
+  subscribe?: boolean;
+};
+
 /**
  * Hook that provides state management for Squid queries, giving access to the data items,
  * the loading status, and any errors encountered during the query execution. It can subscribe to
@@ -27,14 +37,14 @@ type GetReturnType<T> = T extends SnapshotEmitter<infer U> ? U : never;
  *
  * @template T - The expected type of the individual data items returned by the query.
  * @param query - The Squid query.
- * @param subscribe - Determines whether to continuously subscribe to query updates. If `false`, a single snapshot will be fetched.
+ * @param options - Options to control the behavior of the query.
  * @param initialValue - An optional array of initial data items to be used before the query resolves for the first time.
  * @param deps - An array of dependencies that, when changed, will cause the hook to resubscribe to the query updates.
  * @returns An object containing the current state of the query operation: the loading status, the array of data items, and any error.
  */
 export function useQuery<T extends DocumentData>(
   query: T & SnapshotEmitter<any>,
-  subscribe = false,
+  options?: QueryOptions,
   initialValue?: Array<GetReturnType<T>>,
   deps: ReadonlyArray<unknown> = [],
 ): QueryType<GetReturnType<T>> {
@@ -45,8 +55,12 @@ export function useQuery<T extends DocumentData>(
       return [];
     }
   };
+
+  const { enabled, subscribe } = options || {};
+
   const { loading, error, data } = useObservable<GetReturnType<T>[]>(
     () => (subscribe ? query.snapshots() : from(query.snapshot())),
+    { enabled },
     initialValue || peekInitialValue(),
     [JSON.stringify(query.serialize()), subscribe, JSON.stringify(deps)],
   );


### PR DESCRIPTION
This PR makes some significant changes to our `useQuery`, `useDoc`, `useDocs`, `usePagination` and `useObservable`, `usePromise` hooks.

1. The `useQuery`, `useDoc` and `useDocs` hooks now take an `options` parameter instead of a `subscribe` param. The `options` param will include a `subscribe` attribute. This means that `useQuery(query, true)` is now `useQuery(query, { subscribe: true })`. This is a breaking change.

2. `options` has been added as the second param to the `useObservable` and `usePromise` hooks to support the `enabled` option (see below). This is a breaking change.

2. A new `enabled` option can now be passed to all of the hooks above. `enabled` is inspired by [TanStack](https://tanstack.com/query/v4/docs/react/guides/disabling-queries), and is a requested feature (by myself, @jenperson and others). Essentially a query will not be executed until `enabled` is set to `true`. This prevents users from needing to adopt the following pattern, which was becoming more and more common in real applications:
```
const { data, loading } = useObservable(() => {
  if (!userId) return NEVER;
  return collection.query().eq("userId", userId).snapshots();
}, [], [userId])
```

Instead you can now just write:
```
useQuery(collection.query().eq("userId", userId), { enabled: !!userId, subscribe: true })
```