### PR TITLE
Fix: Null Context

### DIFF
--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -21,8 +21,8 @@ export function useCollection<T extends DocumentData>(
 ): CollectionReference<T> {
   const context = React.useContext(SquidContext);
 
-  if (context === undefined) {
-    throw new Error('useSquid must be used within a SquidContext.Provider');
+  if (!context) {
+    throw new Error('useCollection must be used within a SquidContext.Provider');
   }
 
   return useSquid().collection<T>(collectionName, integrationId);

--- a/src/hooks/useSquid.ts
+++ b/src/hooks/useSquid.ts
@@ -13,7 +13,7 @@ import { SquidContext } from '../context';
 export function useSquid(): Squid {
   const context = React.useContext(SquidContext);
 
-  if (context === undefined) {
+  if (!context) {
     throw new Error('useSquid must be used within a SquidContext.Provider');
   }
 


### PR DESCRIPTION
Ensures that an error is thrown when `useSquid` or `useCollection` is used outside of the `SquidContextProvider`. The previous `=== undefined` check was not working, since the context is initialized to `null`.

Also updates the client dependency.