### PR TITLE
useQueue

### DIFF
--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -3,6 +3,7 @@ import { useCollection, useDocs, useQuery } from '@squidcloud/react';
 import { useState } from 'react';
 import Chat from './components/Chat';
 import Pages from './components/Pages';
+import Queue from './components/Queue';
 import Slider from './components/Slider';
 import { randomAge, randomName } from './data/names';
 
@@ -80,6 +81,7 @@ function App(): JSX.Element {
           </div>
           <Pages enabled={enabled} />
           <Chat />
+          <Queue />
         </div>
       )}
       <button style={{ marginTop: '32px' }} onClick={toggle}>

--- a/examples/vite/src/components/Chat.tsx
+++ b/examples/vite/src/components/Chat.tsx
@@ -11,6 +11,7 @@ const Chat = () => {
 
   return (
     <>
+      <h2>Chat</h2>
       <input onChange={(e) => setValue(e.target.value)} value={value} />
       <button onClick={handleClick} disabled={!complete}>
         Chat

--- a/examples/vite/src/components/Queue.tsx
+++ b/examples/vite/src/components/Queue.tsx
@@ -1,0 +1,34 @@
+import { useQueue, useSquid } from '@squidcloud/react';
+import { useState } from 'react';
+
+const Queue = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [value, setValue] = useState('');
+  const squid = useSquid();
+
+  const { produce, data, error } = useQueue<string>(squid.queue('testing'), {
+    enabled,
+  });
+
+  const handlProduce = () => {
+    void produce([value]);
+  };
+
+  const toggleEnabled = () => {
+    setEnabled(!enabled);
+  };
+
+  return (
+    <>
+      <h2>Queue</h2>
+      <span>Data: {data}</span>
+      <span>Error: {error?.message}</span>
+
+      <input onChange={(e) => setValue(e.target.value)} value={value} />
+      <button onClick={handlProduce}>Produce</button>
+      <button onClick={toggleEnabled}>{enabled ? 'Disable' : 'Enable'}</button>
+    </>
+  );
+};
+
+export default Queue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@squidcloud/react",
-  "version": "1.0.47",
+  "version": "1.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@squidcloud/react",
-      "version": "1.0.47",
+      "version": "1.0.46",
       "dependencies": {
         "@squidcloud/client": "^1.0.194",
         "assertic": "^1.0.0"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,4 +8,5 @@ export * from './useObservable';
 export * from './usePagination';
 export * from './usePromise';
 export * from './useQuery';
+export * from './useQueue';
 export * from './useSquid';

--- a/src/hooks/useQueue.ts
+++ b/src/hooks/useQueue.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { QueueManager } from '@squidcloud/client';
+import { useCallback } from 'react';
+import { useObservable } from './useObservable';
+
+/**
+ * Type representing the state of a Squid queue.
+ *
+ * @template T - The type of the data that the queue will return.
+ */
+export type QueueType<T> = {
+  /** The most recent message consumed by the queue. */
+  data: T | null;
+  /** Any error that may have occurred during while consuming messages. */
+  error: any;
+  /** A wrapper around queue.produce. */
+  produce: (messages: Array<T>) => Promise<void>;
+};
+
+export type QueueOptions = {
+  /**
+   * Determines whether the queue beings consuming automatically. Defaults to `true`. When set to `false`, consuming
+   * messages will be paused until `enabled` is set to `true`.
+   */
+  enabled?: boolean;
+};
+
+const DEFAULT_QUEUE_OPTIONS: Required<QueueOptions> = {
+  enabled: true,
+};
+
+export function useQueue<T>(
+  queue: QueueManager,
+  options: QueueOptions = {},
+  deps: ReadonlyArray<unknown> = [],
+): QueueType<T> {
+  const mergedOptions = { ...DEFAULT_QUEUE_OPTIONS, ...options };
+
+  const produce = useCallback(
+    async (messages: any[]): Promise<void> => {
+      await queue.produce(messages);
+    },
+    [JSON.stringify(deps)],
+  );
+
+  const { enabled } = mergedOptions;
+
+  const { error, data } = useObservable<T>(() => queue.consume(), { enabled }, [JSON.stringify(deps)]);
+
+  return { error, data, produce };
+}
+
+export default useQueue;


### PR DESCRIPTION
Adds a `useQueue` hook to support Squid queues.

Usage:
```
const squid = useSquid();
const { data, error, produce } = useQueue(squid.queue('my-topic'))
```
