### PR TITLE
Fix build time errors and warnings

### DIFF
--- a/src/context/SquidContext.tsx
+++ b/src/context/SquidContext.tsx
@@ -2,7 +2,11 @@
 
 import { Squid, SquidOptions } from '@squidcloud/client';
 import React, { useRef } from 'react';
-import { SquidContextType } from '../types';
+
+/** Type representing the context for the Squid library. */
+export type SquidContextType = {
+  squid: Squid | null;
+};
 
 /**
  * React Context for Squid.

--- a/src/hoc/withServerQuery/WithQueryServer.tsx
+++ b/src/hoc/withServerQuery/WithQueryServer.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_WITH_QUERY_OPTIONS,
   WithQueryOptions,
   WithQueryProps,
-} from './index';
+} from './types';
 
 type PropTypes<C extends React.ComponentType<any>, T> = {
   Component: C;

--- a/src/hoc/withServerQuery/index.tsx
+++ b/src/hoc/withServerQuery/index.tsx
@@ -1,27 +1,9 @@
 import { SnapshotEmitter } from '@squidcloud/client';
 import React from 'react';
 import WithQueryServer from './WithQueryServer';
+import { WithQueryProps, WithQueryOptions } from './types';
 
-export interface WithQueryProps<T> {
-  /**
-   * The data returned from the `query` passed to the `withServerQuery` HOC. On initial render, the data will be
-   * passed from the server. If the component subscribes to query snaphosts, the data will be updated whenever the
-   * query results change.
-   */
-  data: Array<T>;
-}
-
-export type WithQueryOptions = {
-  /**
-   * If true, the Component will subscribe to the query snapshots. Defaults to `true`.
-   */
-  subscribe?: boolean;
-};
-
-/** @internal */
-export const DEFAULT_WITH_QUERY_OPTIONS: Required<WithQueryOptions> = {
-  subscribe: true,
-};
+export { WithQueryProps, WithQueryOptions, DEFAULT_WITH_QUERY_OPTIONS } from './types';
 
 /**
  * Higher Order Component (HOC) to wrap a component with a server query.

--- a/src/hoc/withServerQuery/types.ts
+++ b/src/hoc/withServerQuery/types.ts
@@ -1,0 +1,20 @@
+export interface WithQueryProps<T> {
+  /**
+   * The data returned from the `query` passed to the `withServerQuery` HOC. On initial render, the data will be
+   * passed from the server. If the component subscribes to query snaphosts, the data will be updated whenever the
+   * query results change.
+   */
+  data: Array<T>;
+}
+
+export type WithQueryOptions = {
+  /**
+   * If true, the Component will subscribe to the query snapshots. Defaults to `true`.
+   */
+  subscribe?: boolean;
+};
+
+/** @internal */
+export const DEFAULT_WITH_QUERY_OPTIONS: Required<WithQueryOptions> = {
+  subscribe: true,
+};

--- a/src/hooks/useQueue.ts
+++ b/src/hooks/useQueue.ts
@@ -50,5 +50,3 @@ export function useQueue<T>(
 
   return { error, data, produce };
 }
-
-export default useQueue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './context';
 export * from './hoc';
 export * from './hooks';
-export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,0 @@
-import { Squid } from '@squidcloud/client';
-
-/** Type representing the context for the Squid library. */
-export type SquidContextType = {
-  squid: Squid | null;
-};


### PR DESCRIPTION
This PR fixes only generic TS/JS errors and warning.
React logic warnings will be fixed in a separate PR.

Before:
```
/home/mint/tools/node/bin/npm run build

> @squidcloud/react@1.0.119 build
> rollup -c && yalc push


/home/mint/work/squid-react/src/context/index.ts, /home/mint/work/squid-react/src/context/SquidContext.tsx, /home/mint/work/squid-react/src/hoc/index.ts, /home/mint/work/squid-react/src/hoc/withServerQuery/index.tsx, /home/mint/work/squid-react/src/hoc/withServerQuery/WithQueryClient.tsx, /home/mint/work/squid-react/src/hoc/withServerQuery/WithQueryServer.tsx, /home/mint/work/squid-react/src/hooks/index.ts, /home/mint/work/squid-react/src/hooks/useAiAgent.ts, /home/mint/work/squid-react/src/hooks/useAiChat.ts, /home/mint/work/squid-react/src/hooks/useCollection.ts, /home/mint/work/squid-react/src/hooks/useDoc.ts, /home/mint/work/squid-react/src/hooks/useDocs.ts, /home/mint/work/squid-react/src/hooks/useObservable.ts, /home/mint/work/squid-react/src/hooks/usePagination.ts, /home/mint/work/squid-react/src/hooks/usePromise.ts, /home/mint/work/squid-react/src/hooks/useQuery.ts, /home/mint/work/squid-react/src/hooks/useQueue.ts, /home/mint/work/squid-react/src/hooks/useSquid.ts, /home/mint/work/squid-react/src/index.ts, /home/mint/work/squid-react/src/types.ts → dist/cjs...
(!) Circular dependency
src/hoc/withServerQuery/index.tsx -> src/hoc/withServerQuery/WithQueryServer.tsx -> src/hoc/withServerQuery/index.tsx
(!) Mixing named and default exports
https://rollupjs.org/configuration-options/#output-exports
The following entry modules are using named and default exports together:
src/hooks/useQueue.ts

Consumers of your bundle will have to use chunk.default to access their default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.
(!) Generated an empty chunk
"types"
created dist/cjs in 3s
@squidcloud/react@1.0.119 published in store.

```

After:

```
/home/mint/tools/node/bin/npm run build

> @squidcloud/react@1.0.119 build
> rollup -c && yalc push


/home/mint/work/squid-react/src/context/index.ts, /home/mint/work/squid-react/src/context/SquidContext.tsx, /home/mint/work/squid-react/src/hoc/index.ts, /home/mint/work/squid-react/src/hoc/withServerQuery/index.tsx, /home/mint/work/squid-react/src/hoc/withServerQuery/types.ts, /home/mint/work/squid-react/src/hoc/withServerQuery/WithQueryClient.tsx, /home/mint/work/squid-react/src/hoc/withServerQuery/WithQueryServer.tsx, /home/mint/work/squid-react/src/hooks/index.ts, /home/mint/work/squid-react/src/hooks/useAiAgent.ts, /home/mint/work/squid-react/src/hooks/useAiChat.ts, /home/mint/work/squid-react/src/hooks/useCollection.ts, /home/mint/work/squid-react/src/hooks/useDoc.ts, /home/mint/work/squid-react/src/hooks/useDocs.ts, /home/mint/work/squid-react/src/hooks/useObservable.ts, /home/mint/work/squid-react/src/hooks/usePagination.ts, /home/mint/work/squid-react/src/hooks/usePromise.ts, /home/mint/work/squid-react/src/hooks/useQuery.ts, /home/mint/work/squid-react/src/hooks/useQueue.ts, /home/mint/work/squid-react/src/hooks/useSquid.ts, /home/mint/work/squid-react/src/index.ts → dist/cjs...
created dist/cjs in 1.3s
@squidcloud/react@1.0.119 published in store.

```